### PR TITLE
Use BlocConsumer instead of a nested BlocListener and BlocBuilder

### DIFF
--- a/lib/src/pages/cuba_page.dart
+++ b/lib/src/pages/cuba_page.dart
@@ -34,22 +34,20 @@ class CubaPageState extends State<CubaPage> {
     try {
       return BlocProvider(
         create: (context) => HomeBloc(),
-        child: BlocListener<HomeBloc, HomeState>(
+        child: BlocConsumer<HomeBloc, HomeState>(
           listener: (context, state) {
             if (state is LoadedHomeState) {
               refreshCompleter?.complete();
               refreshCompleter = Completer();
             }
           },
-          child: BlocBuilder<HomeBloc, HomeState>(
-            builder: (context, state) {
-              return Scaffold(
-                appBar: getAppBarTabs(context, state),
-                drawer: getHomeDrawer(context, state),
-                body: getBody(context, state),
-              );
-            },
-          ),
+          builder: (context, state) {
+            return Scaffold(
+              appBar: getAppBarTabs(context, state),
+              drawer: getHomeDrawer(context, state),
+              body: getBody(context, state),
+            );
+          },
         ),
       );
     } catch (e) {

--- a/lib/src/pages/jt_news_page.dart
+++ b/lib/src/pages/jt_news_page.dart
@@ -37,22 +37,20 @@ class JTNewsPageState extends State<JTNewsPage> {
     try {
       return BlocProvider(
         create: (context) => JTNewsBloc(),
-        child: BlocListener<JTNewsBloc, JTNewsState>(
+        child: BlocConsumer<JTNewsBloc, JTNewsState>(
           listener: (context, state) {
             if (state is LoadedJTNewsState) {
               refreshCompleter?.complete();
               refreshCompleter = Completer();
             }
           },
-          child: BlocBuilder<JTNewsBloc, JTNewsState>(
-            builder: (context, state) {
-              return Scaffold(
-                appBar: getAppBar(context, state),
-                drawer: getHomeDrawer(context, state),
-                body: getBody(context, state),
-              );
-            },
-          ),
+          builder: (context, state) {
+            return Scaffold(
+              appBar: getAppBar(context, state),
+              drawer: getHomeDrawer(context, state),
+              body: getBody(context, state),
+            );
+          },
         ),
       );
     } catch (e) {

--- a/lib/src/pages/world_page.dart
+++ b/lib/src/pages/world_page.dart
@@ -34,22 +34,20 @@ class WorldPageState extends State<WorldPage> {
     try {
       return BlocProvider(
         create: (context) => HomeBloc(),
-        child: BlocListener<HomeBloc, HomeState>(
+        child: BlocConsumer<HomeBloc, HomeState>(
           listener: (context, state) {
             if (state is LoadedHomeState) {
               refreshCompleter?.complete();
               refreshCompleter = Completer();
             }
           },
-          child: BlocBuilder<HomeBloc, HomeState>(
-            builder: (context, state) {
-              return Scaffold(
-                appBar: getAppBar(context, state),
-                drawer: getHomeDrawer(context, state),
-                body: getBody(context, state),
-              );
-            },
-          ),
+          builder: (context, state) {
+            return Scaffold(
+              appBar: getAppBar(context, state),
+              drawer: getHomeDrawer(context, state),
+              body: getBody(context, state),
+            );
+          },
         ),
       );
     } catch (e) {


### PR DESCRIPTION
follow [docs recommendation](https://bloclibrary.dev/#/flutterbloccoreconcepts?id=blocconsumer) of using BlocConsumer instead of a nested BlocListener and BlocBuilder.
"...BlocConsumer exposes a builder and listener in order to react to new states. BlocConsumer is analogous to a nested BlocListener and BlocBuilder but reduces the amount of boilerplate needed..."