### PR TITLE
Improve home navigation

### DIFF
--- a/lib/src/pages/cuba_page.dart
+++ b/lib/src/pages/cuba_page.dart
@@ -49,42 +49,6 @@ class CubaPageState extends State<CubaPage> {
     }
   }
 
-  Widget getAppBar(BuildContext context, HomeState state) {
-    return AppBar(
-      centerTitle: true,
-      title: Text(Constants.appName),
-      actions: <Widget>[
-        IconButton(
-          icon: Icon(Icons.refresh),
-          color: Colors.white,
-          onPressed: () {
-            BlocProvider.of<HomeBloc>(context).add(FetchHomeEvent());
-          },
-        ),
-      ],
-    );
-  }
-
-  Widget getAppBarTabs(BuildContext context, HomeState state) {
-    return AppBar(
-      centerTitle: true,
-      title: Text(Constants.appName),
-      actions: <Widget>[
-        IconButton(
-          icon: Icon(Icons.refresh),
-          color: Colors.white,
-          onPressed: () {
-            BlocProvider.of<HomeBloc>(context).add(FetchHomeEvent());
-          },
-        ),
-      ],
-    );
-  }
-
-  Widget getHomeDrawer(BuildContext context, HomeState state) {
-    return HomeDrawerWidget();
-  }
-
   Widget getBody(BuildContext context, HomeState state) {
     if (state is InitialHomeState) {
       BlocProvider.of<HomeBloc>(context).add(LoadHomeEvent());
@@ -123,71 +87,64 @@ class CubaPageState extends State<CubaPage> {
   }
 
   Widget getError() {
-    return Scaffold(
-      appBar: AppBar(
-        centerTitle: true,
-        title: Text(Constants.appName),
-      ),
-      drawer: HomeDrawerWidget(),
-      body: ListView(
-        children: <Widget>[
-          Container(
-            margin: EdgeInsets.all(30),
-            child: Icon(
-              Icons.error_outline,
-              color: Constants.primaryColor,
-              size: 150,
-            ),
+    return ListView(
+      children: <Widget>[
+        Container(
+          margin: EdgeInsets.all(30),
+          child: Icon(
+            Icons.error_outline,
+            color: Constants.primaryColor,
+            size: 150,
           ),
-          Text(
-            'Ha ocurrido un error',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              color: Constants.primaryColor,
-              fontWeight: FontWeight.bold,
-              fontSize: 30,
-            ),
+        ),
+        Text(
+          'Ha ocurrido un error',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            color: Constants.primaryColor,
+            fontWeight: FontWeight.bold,
+            fontSize: 30,
           ),
-          Container(
-            margin: EdgeInsets.all(20),
-            child: Container(
-              padding: EdgeInsets.all(10),
-              child: Text(
-                'El equipo de desarrollo de la aplicación le pide disculpas '
-                'y le invita al grupo de Telegram para que reporte el '
-                'problema y así poder solucionarlo ayudando a los restantes '
-                'usuarios. Gracias de antemano.',
-                textAlign: TextAlign.left,
-                style: TextStyle(
-                  color: Constants.primaryColor,
-                  fontWeight: FontWeight.w600,
-                  fontSize: 16,
-                ),
+        ),
+        Container(
+          margin: EdgeInsets.all(20),
+          child: Container(
+            padding: EdgeInsets.all(10),
+            child: Text(
+              'El equipo de desarrollo de la aplicación le pide disculpas '
+              'y le invita al grupo de Telegram para que reporte el '
+              'problema y así poder solucionarlo ayudando a los restantes '
+              'usuarios. Gracias de antemano.',
+              textAlign: TextAlign.left,
+              style: TextStyle(
+                color: Constants.primaryColor,
+                fontWeight: FontWeight.w600,
+                fontSize: 16,
               ),
             ),
           ),
-          Container(
-            padding: EdgeInsets.symmetric(horizontal: 50),
-            child: GFButton(
-              text: 'Grupo de soporte en Telegram',
-              textColor: Constants.primaryColor,
-              color: Constants.primaryColor,
-              size: GFSize.LARGE,
-              shape: GFButtonShape.pills,
-              type: GFButtonType.outline2x,
-              fullWidthButton: true,
-              onPressed: () async {
-                const url = 'https://t.me/covid19cubadatachat';
-                if (await canLaunch(url)) {
-                  await launch(url);
-                } else {
-                  log('Could not launch $url');
-                }
-              },
-            ),
+        ),
+        Container(
+          padding: EdgeInsets.symmetric(horizontal: 50),
+          child: GFButton(
+            text: 'Grupo de soporte en Telegram',
+            textColor: Constants.primaryColor,
+            color: Constants.primaryColor,
+            size: GFSize.LARGE,
+            shape: GFButtonShape.pills,
+            type: GFButtonType.outline2x,
+            fullWidthButton: true,
+            onPressed: () async {
+              const url = 'https://t.me/covid19cubadatachat';
+              if (await canLaunch(url)) {
+                await launch(url);
+              } else {
+                log('Could not launch $url');
+              }
+            },
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/lib/src/pages/cuba_page.dart
+++ b/lib/src/pages/cuba_page.dart
@@ -32,23 +32,16 @@ class CubaPageState extends State<CubaPage> {
   @override
   Widget build(BuildContext context) {
     try {
-      return BlocProvider(
-        create: (context) => HomeBloc(),
-        child: BlocConsumer<HomeBloc, HomeState>(
-          listener: (context, state) {
-            if (state is LoadedHomeState) {
-              refreshCompleter?.complete();
-              refreshCompleter = Completer();
-            }
-          },
-          builder: (context, state) {
-            return Scaffold(
-              appBar: getAppBarTabs(context, state),
-              drawer: getHomeDrawer(context, state),
-              body: getBody(context, state),
-            );
-          },
-        ),
+      return BlocConsumer<HomeBloc, HomeState>(
+        listener: (context, state) {
+          if (state is LoadedHomeState) {
+            refreshCompleter?.complete();
+            refreshCompleter = Completer();
+          }
+        },
+        builder: (context, state) {
+          return getBody(context, state);
+        },
       );
     } catch (e) {
       log(e.toString());

--- a/lib/src/pages/home_page.dart
+++ b/lib/src/pages/home_page.dart
@@ -6,9 +6,12 @@ import 'package:badges/badges.dart';
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:preferences/preference_service.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:covid19cuba/src/blocs/blocs.dart';
 
 import 'package:covid19cuba/src/pages/pages.dart';
 import 'package:covid19cuba/src/utils/utils.dart';
+import 'package:covid19cuba/src/widgets/widgets.dart';
 import 'package:covid19cuba/src/utils/cuba_icon_icons.dart';
 
 class HomePage extends StatefulWidget {
@@ -78,24 +81,73 @@ class HomePageState extends State<HomePage>
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: IndexedStack(
-        index: currentTabIndex,
-        children: pages,
-      ),
-      bottomNavigationBar: BottomNavigationBar(
-        backgroundColor: Constants.primaryColor,
-        selectedItemColor: Colors.white,
-        unselectedItemColor: Colors.grey,
-        items: getTabs(),
-        currentIndex: currentTabIndex,
-        type: BottomNavigationBarType.fixed,
-        onTap: (int index) {
-          setState(() {
-            currentTabIndex = index;
-          });
-        },
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<HomeBloc>(
+          create: (context) => HomeBloc(),
+        ),
+        BlocProvider<JTNewsBloc>(
+          create: (context) => JTNewsBloc(),
+        ),
+      ],
+      child: Scaffold(
+        appBar: AppBar(
+          elevation: 0,
+          title: Text(Constants.appName),
+          centerTitle: true,
+          actions: _getAppBarActions(context, currentTabIndex),
+        ),
+        drawer: HomeDrawerWidget(),
+        body: IndexedStack(
+          index: currentTabIndex,
+          children: pages,
+        ),
+        bottomNavigationBar: BottomNavigationBar(
+          backgroundColor: Constants.primaryColor,
+          selectedItemColor: Colors.white,
+          unselectedItemColor: Colors.grey,
+          items: getTabs(),
+          currentIndex: currentTabIndex,
+          type: BottomNavigationBarType.fixed,
+          onTap: (int index) {
+            setState(() {
+              currentTabIndex = index;
+            });
+          },
+        ),
       ),
     );
+  }
+
+  List<Widget> _getAppBarActions(BuildContext context, int index) {
+    if (index == 1 || index == 2) {
+      return <Widget>[
+        BlocBuilder<HomeBloc, HomeState>(
+          builder: (context, state) {
+            return IconButton(
+              icon: Icon(Icons.refresh),
+              color: Colors.white,
+              onPressed: () {
+                BlocProvider.of<HomeBloc>(context).add(FetchHomeEvent());
+              },
+            );
+          },
+        ),
+      ];
+    } else if (index == 3) {
+      return <Widget>[
+        BlocBuilder<JTNewsBloc, JTNewsState>(
+          builder: (context, state) {
+            return IconButton(
+              icon: Icon(Icons.refresh),
+              color: Colors.white,
+              onPressed: () {
+                BlocProvider.of<JTNewsBloc>(context).add(FetchJTNewsEvent());
+              },
+            );
+          },
+        ),
+      ];
+    } else return <Widget>[];
   }
 }

--- a/lib/src/pages/info_page.dart
+++ b/lib/src/pages/info_page.dart
@@ -40,208 +40,199 @@ class InfoPageState extends State<InfoPage> {
   @override
   Widget build(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
-    return Scaffold(
-      backgroundColor: Colors.transparent,
-      appBar: AppBar(
-        elevation: 0,
-        title: Text(Constants.appName),
-        centerTitle: true,
-      ),
-      drawer: HomeDrawerWidget(),
-      body: SingleChildScrollView(
-        controller: controller,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            InfoHeader(
-              image: 'assets/images/doctor.svg',
-              textTop: 'Conozca acerca',
-              textBottom: 'de la Covid-19',
-              offset: offset,
+    return SingleChildScrollView(
+      controller: controller,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          InfoHeader(
+            image: 'assets/images/doctor.svg',
+            textTop: 'Conozca acerca',
+            textBottom: 'de la Covid-19',
+            offset: offset,
+          ),
+          Container(
+            margin: EdgeInsets.symmetric(horizontal: 10),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: <Widget>[
+                Container(
+                  margin: EdgeInsets.only(left: 5),
+                  child: Text(
+                    'Síntomas principales',
+                    style: Constants.kTitleTextStyle,
+                  ),
+                ),
+              ],
             ),
-            Container(
-              margin: EdgeInsets.symmetric(horizontal: 10),
+          ),
+          Container(height: 10),
+          Container(
+            child: SingleChildScrollView(
+              padding: EdgeInsets.symmetric(vertical: 5, horizontal: 10),
+              scrollDirection: Axis.horizontal,
               child: Row(
-                mainAxisAlignment: MainAxisAlignment.start,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.max,
                 children: <Widget>[
+                  smallCardContainer(
+                    'assets/images/dolor_cabeza.svg',
+                    'Dolor\nde cabeza',
+                    context,
+                  ),
                   Container(
-                    margin: EdgeInsets.only(left: 5),
-                    child: Text(
-                      'Síntomas principales',
-                      style: Constants.kTitleTextStyle,
-                    ),
+                    width: 5,
+                  ),
+                  smallCardContainer(
+                    'assets/images/dolor_garganta.svg',
+                    'Dolor\nde garganta',
+                    context,
+                  ),
+                  Container(
+                    width: 5,
+                  ),
+                  smallCardContainer(
+                    'assets/images/tos.svg',
+                    'Tos\n',
+                    context,
+                  ),
+                  Container(
+                    width: 5,
+                  ),
+                  smallCardContainer(
+                    'assets/images/fiebre.svg',
+                    'Fiebre\n',
+                    context,
+                  ),
+                  Container(
+                    width: 5,
+                  ),
+                  smallCardContainer(
+                    'assets/images/falta_aire.svg',
+                    'Dificultad\npara respirar',
+                    context,
                   ),
                 ],
               ),
             ),
-            Container(height: 10),
-            Container(
-              child: SingleChildScrollView(
-                padding: EdgeInsets.symmetric(vertical: 5, horizontal: 10),
-                scrollDirection: Axis.horizontal,
-                child: Row(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  mainAxisSize: MainAxisSize.max,
-                  children: <Widget>[
-                    smallCardContainer(
-                      'assets/images/dolor_cabeza.svg',
-                      'Dolor\nde cabeza',
-                      context,
-                    ),
-                    Container(
-                      width: 5,
-                    ),
-                    smallCardContainer(
-                      'assets/images/dolor_garganta.svg',
-                      'Dolor\nde garganta',
-                      context,
-                    ),
-                    Container(
-                      width: 5,
-                    ),
-                    smallCardContainer(
-                      'assets/images/tos.svg',
-                      'Tos\n',
-                      context,
-                    ),
-                    Container(
-                      width: 5,
-                    ),
-                    smallCardContainer(
-                      'assets/images/fiebre.svg',
-                      'Fiebre\n',
-                      context,
-                    ),
-                    Container(
-                      width: 5,
-                    ),
-                    smallCardContainer(
-                      'assets/images/falta_aire.svg',
-                      'Dificultad\npara respirar',
-                      context,
-                    ),
-                  ],
-                ),
-              ),
-            ),
-            Container(
-              margin: EdgeInsets.symmetric(horizontal: 10),
-              child: Card(
-                color: Constants.primaryColor,
-                child: Container(
-                  margin: EdgeInsets.all(20),
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: <Widget>[
-                      Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: <Widget>[
-                          Text(
-                            'No salga de casa\n'
-                            'Así detendremos a la Covid-19\n'
-                            '#QuédateEnCasa',
-                            style: TextStyle(
-                              color: Colors.white,
-                              fontSize: 16,
-                              fontWeight: FontWeight.w600,
-                            ),
-                          ),
-                          InkWell(
-                            onTap: () {
-                              Navigator.of(context).push(
-                                MaterialPageRoute(
-                                  builder: (context) => InfoMorePage(),
-                                ),
-                              );
-                            },
-                            child: Container(
-                              margin: EdgeInsets.only(top: 20),
-                              padding: EdgeInsets.all(8),
-                              decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(8),
-                                color: Colors.red,
-                              ),
-                              child: Text(
-                                'Saber más',
-                                style: TextStyle(
-                                  color: Colors.white,
-                                  fontWeight: FontWeight.w800,
-                                ),
-                              ),
-                            ),
-                          ),
-                        ],
-                      ),
-                      Container(width: 30),
-                      Flexible(
-                        child: Image.asset(
-                          'assets/images/casa.png',
-                          width: width * 0.2,
-                          fit: BoxFit.cover,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-            Container(
-              margin: EdgeInsets.symmetric(horizontal: 10, vertical: 10),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: <Widget>[
-                  Container(
-                    padding: EdgeInsets.only(left: 5),
-                    child: Text(
-                      'Prevención',
-                      style: Constants.kTitleTextStyle,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            Container(
-              child: SingleChildScrollView(
-                padding: EdgeInsets.symmetric(vertical: 5, horizontal: 10),
-                scrollDirection: Axis.horizontal,
+          ),
+          Container(
+            margin: EdgeInsets.symmetric(horizontal: 10),
+            child: Card(
+              color: Constants.primaryColor,
+              child: Container(
+                margin: EdgeInsets.all(20),
                 child: Row(
                   mainAxisAlignment: MainAxisAlignment.start,
                   children: <Widget>[
-                    smallCardContainer(
-                      'assets/images/clean_hands.svg',
-                      'Lave\nsus manos',
-                      context,
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          'No salga de casa\n'
+                          'Así detendremos a la Covid-19\n'
+                          '#QuédateEnCasa',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        InkWell(
+                          onTap: () {
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (context) => InfoMorePage(),
+                              ),
+                            );
+                          },
+                          child: Container(
+                            margin: EdgeInsets.only(top: 20),
+                            padding: EdgeInsets.all(8),
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(8),
+                              color: Colors.red,
+                            ),
+                            child: Text(
+                              'Saber más',
+                              style: TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.w800,
+                              ),
+                            ),
+                          ),
+                        ),
+                      ],
                     ),
-                    Container(
-                      width: 5,
-                    ),
-                    smallCardContainer(
-                      'assets/images/man_mask.svg',
-                      'Use\nmascarilla',
-                      context,
-                    ),
-                    Container(
-                      width: 5,
-                    ),
-                    smallCardContainer(
-                      'assets/images/dont_face_touch.svg',
-                      'No se toque\nla cara',
-                      context,
-                    ),
-                    Container(
-                      width: 5,
-                    ),
-                    smallCardContainer(
-                      'assets/images/distance_keep_social.png',
-                      'Distancia\nsocial',
-                      context,
+                    Container(width: 30),
+                    Flexible(
+                      child: Image.asset(
+                        'assets/images/casa.png',
+                        width: width * 0.2,
+                        fit: BoxFit.cover,
+                      ),
                     ),
                   ],
                 ),
               ),
             ),
-          ],
-        ),
+          ),
+          Container(
+            margin: EdgeInsets.symmetric(horizontal: 10, vertical: 10),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: <Widget>[
+                Container(
+                  padding: EdgeInsets.only(left: 5),
+                  child: Text(
+                    'Prevención',
+                    style: Constants.kTitleTextStyle,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Container(
+            child: SingleChildScrollView(
+              padding: EdgeInsets.symmetric(vertical: 5, horizontal: 10),
+              scrollDirection: Axis.horizontal,
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: <Widget>[
+                  smallCardContainer(
+                    'assets/images/clean_hands.svg',
+                    'Lave\nsus manos',
+                    context,
+                  ),
+                  Container(
+                    width: 5,
+                  ),
+                  smallCardContainer(
+                    'assets/images/man_mask.svg',
+                    'Use\nmascarilla',
+                    context,
+                  ),
+                  Container(
+                    width: 5,
+                  ),
+                  smallCardContainer(
+                    'assets/images/dont_face_touch.svg',
+                    'No se toque\nla cara',
+                    context,
+                  ),
+                  Container(
+                    width: 5,
+                  ),
+                  smallCardContainer(
+                    'assets/images/distance_keep_social.png',
+                    'Distancia\nsocial',
+                    context,
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/src/pages/jt_news_page.dart
+++ b/lib/src/pages/jt_news_page.dart
@@ -35,23 +35,16 @@ class JTNewsPageState extends State<JTNewsPage> {
   @override
   Widget build(BuildContext context) {
     try {
-      return BlocProvider(
-        create: (context) => JTNewsBloc(),
-        child: BlocConsumer<JTNewsBloc, JTNewsState>(
-          listener: (context, state) {
-            if (state is LoadedJTNewsState) {
-              refreshCompleter?.complete();
-              refreshCompleter = Completer();
-            }
-          },
-          builder: (context, state) {
-            return Scaffold(
-              appBar: getAppBar(context, state),
-              drawer: getHomeDrawer(context, state),
-              body: getBody(context, state),
-            );
-          },
-        ),
+      return BlocConsumer<JTNewsBloc, JTNewsState>(
+        listener: (context, state) {
+          if (state is LoadedJTNewsState) {
+            refreshCompleter?.complete();
+            refreshCompleter = Completer();
+          }
+        },
+        builder: (context, state) {
+          return getBody(context, state);
+        },
       );
     } catch (e) {
       log(e.toString());

--- a/lib/src/pages/jt_news_page.dart
+++ b/lib/src/pages/jt_news_page.dart
@@ -52,28 +52,6 @@ class JTNewsPageState extends State<JTNewsPage> {
     }
   }
 
-  Widget getAppBar(BuildContext context, JTNewsState state) {
-    return AppBar(
-      centerTitle: true,
-      title: Text(Constants.appName),
-      actions: <Widget>[
-        IconButton(
-          icon: Icon(Icons.refresh),
-          color: Colors.white,
-          onPressed: () {
-            BlocProvider.of<JTNewsBloc>(context).add(
-              FetchJTNewsEvent(),
-            );
-          },
-        ),
-      ],
-    );
-  }
-
-  Widget getHomeDrawer(BuildContext context, JTNewsState state) {
-    return HomeDrawerWidget();
-  }
-
   Widget getBody(BuildContext context, JTNewsState state) {
     if (state is InitialJTNewsState) {
       BlocProvider.of<JTNewsBloc>(context).add(LoadJTNewsEvent());
@@ -294,71 +272,64 @@ class JTNewsPageState extends State<JTNewsPage> {
   }
 
   Widget getError() {
-    return Scaffold(
-      appBar: AppBar(
-        centerTitle: true,
-        title: Text(Constants.appName),
-      ),
-      drawer: HomeDrawerWidget(),
-      body: ListView(
-        children: <Widget>[
-          Container(
-            margin: EdgeInsets.all(30),
-            child: Icon(
-              Icons.error_outline,
-              color: Constants.primaryColor,
-              size: 150,
-            ),
+    return ListView(
+      children: <Widget>[
+        Container(
+          margin: EdgeInsets.all(30),
+          child: Icon(
+            Icons.error_outline,
+            color: Constants.primaryColor,
+            size: 150,
           ),
-          Text(
-            'Ha ocurrido un error',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              color: Constants.primaryColor,
-              fontWeight: FontWeight.bold,
-              fontSize: 30,
-            ),
+        ),
+        Text(
+          'Ha ocurrido un error',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            color: Constants.primaryColor,
+            fontWeight: FontWeight.bold,
+            fontSize: 30,
           ),
-          Container(
-            margin: EdgeInsets.all(20),
-            child: Container(
-              padding: EdgeInsets.all(10),
-              child: Text(
-                'El equipo de desarrollo de la aplicación le pide disculpas '
-                'y le invita al grupo de Telegram para que reporte el '
-                'problema y así poder solucionarlo ayudando a los restantes '
-                'usuarios. Gracias de antemano.',
-                textAlign: TextAlign.left,
-                style: TextStyle(
-                  color: Constants.primaryColor,
-                  fontWeight: FontWeight.w600,
-                  fontSize: 16,
-                ),
+        ),
+        Container(
+          margin: EdgeInsets.all(20),
+          child: Container(
+            padding: EdgeInsets.all(10),
+            child: Text(
+              'El equipo de desarrollo de la aplicación le pide disculpas '
+              'y le invita al grupo de Telegram para que reporte el '
+              'problema y así poder solucionarlo ayudando a los restantes '
+              'usuarios. Gracias de antemano.',
+              textAlign: TextAlign.left,
+              style: TextStyle(
+                color: Constants.primaryColor,
+                fontWeight: FontWeight.w600,
+                fontSize: 16,
               ),
             ),
           ),
-          Container(
-            padding: EdgeInsets.symmetric(horizontal: 50),
-            child: GFButton(
-              text: 'Grupo de soporte en Telegram',
-              textColor: Constants.primaryColor,
-              color: Constants.primaryColor,
-              size: GFSize.LARGE,
-              shape: GFButtonShape.pills,
-              type: GFButtonType.outline2x,
-              fullWidthButton: true,
-              onPressed: () async {
-                const url = 'https://t.me/covid19cubadatachat';
-                if (await canLaunch(url)) {
-                  await launch(url);
-                } else {
-                  log('Could not launch $url');
-                }
-              },
-            ),
+        ),
+        Container(
+          padding: EdgeInsets.symmetric(horizontal: 50),
+          child: GFButton(
+            text: 'Grupo de soporte en Telegram',
+            textColor: Constants.primaryColor,
+            color: Constants.primaryColor,
+            size: GFSize.LARGE,
+            shape: GFButtonShape.pills,
+            type: GFButtonType.outline2x,
+            fullWidthButton: true,
+            onPressed: () async {
+              const url = 'https://t.me/covid19cubadatachat';
+              if (await canLaunch(url)) {
+                await launch(url);
+              } else {
+                log('Could not launch $url');
+              }
+            },
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/lib/src/pages/webview_page.dart
+++ b/lib/src/pages/webview_page.dart
@@ -94,25 +94,7 @@ class WebViewPageState extends State<WebViewPage>
         }
         return true;
       },
-      child: Scaffold(
-        appBar: AppBar(
-          elevation: 0,
-          title: Text(Constants.appName),
-          centerTitle: true,
-          actions: <Widget>[
-            IconButton(
-              icon: Icon(Icons.refresh),
-              onPressed: () {
-                if (controller != null) {
-                  controller.reload();
-                }
-              },
-            ),
-          ],
-        ),
-        drawer: HomeDrawerWidget(),
-        body: webView,
-      ),
+      child: webView,
     );
   }
 }

--- a/lib/src/pages/world_page.dart
+++ b/lib/src/pages/world_page.dart
@@ -32,23 +32,16 @@ class WorldPageState extends State<WorldPage> {
   @override
   Widget build(BuildContext context) {
     try {
-      return BlocProvider(
-        create: (context) => HomeBloc(),
-        child: BlocConsumer<HomeBloc, HomeState>(
-          listener: (context, state) {
-            if (state is LoadedHomeState) {
-              refreshCompleter?.complete();
-              refreshCompleter = Completer();
-            }
-          },
-          builder: (context, state) {
-            return Scaffold(
-              appBar: getAppBar(context, state),
-              drawer: getHomeDrawer(context, state),
-              body: getBody(context, state),
-            );
-          },
-        ),
+      return BlocConsumer<HomeBloc, HomeState>(
+        listener: (context, state) {
+          if (state is LoadedHomeState) {
+            refreshCompleter?.complete();
+            refreshCompleter = Completer();
+          }
+        },
+        builder: (context, state) {
+          return getBody(context, state);
+        },
       );
     } catch (e) {
       log(e.toString());

--- a/lib/src/pages/world_page.dart
+++ b/lib/src/pages/world_page.dart
@@ -49,26 +49,6 @@ class WorldPageState extends State<WorldPage> {
     }
   }
 
-  Widget getAppBar(BuildContext context, HomeState state) {
-    return AppBar(
-      centerTitle: true,
-      title: Text(Constants.appName),
-      actions: <Widget>[
-        IconButton(
-          icon: Icon(Icons.refresh),
-          color: Colors.white,
-          onPressed: () {
-            BlocProvider.of<HomeBloc>(context).add(FetchHomeEvent());
-          },
-        ),
-      ],
-    );
-  }
-
-  Widget getHomeDrawer(BuildContext context, HomeState state) {
-    return HomeDrawerWidget();
-  }
-
   Widget getBody(BuildContext context, HomeState state) {
     if (state is InitialHomeState) {
       BlocProvider.of<HomeBloc>(context).add(LoadHomeEvent());
@@ -107,71 +87,64 @@ class WorldPageState extends State<WorldPage> {
   }
 
   Widget getError() {
-    return Scaffold(
-      appBar: AppBar(
-        centerTitle: true,
-        title: Text(Constants.appName),
-      ),
-      drawer: HomeDrawerWidget(),
-      body: ListView(
-        children: <Widget>[
-          Container(
-            margin: EdgeInsets.all(30),
-            child: Icon(
-              Icons.error_outline,
-              color: Constants.primaryColor,
-              size: 150,
-            ),
+    return ListView(
+      children: <Widget>[
+        Container(
+          margin: EdgeInsets.all(30),
+          child: Icon(
+            Icons.error_outline,
+            color: Constants.primaryColor,
+            size: 150,
           ),
-          Text(
-            'Ha ocurrido un error',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              color: Constants.primaryColor,
-              fontWeight: FontWeight.bold,
-              fontSize: 30,
-            ),
+        ),
+        Text(
+          'Ha ocurrido un error',
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            color: Constants.primaryColor,
+            fontWeight: FontWeight.bold,
+            fontSize: 30,
           ),
-          Container(
-            margin: EdgeInsets.all(20),
-            child: Container(
-              padding: EdgeInsets.all(10),
-              child: Text(
-                'El equipo de desarrollo de la aplicación le pide disculpas '
-                'y le invita al grupo de Telegram para que reporte el '
-                'problema y así poder solucionarlo ayudando a los restantes '
-                'usuarios. Gracias de antemano.',
-                textAlign: TextAlign.left,
-                style: TextStyle(
-                  color: Constants.primaryColor,
-                  fontWeight: FontWeight.w600,
-                  fontSize: 16,
-                ),
+        ),
+        Container(
+          margin: EdgeInsets.all(20),
+          child: Container(
+            padding: EdgeInsets.all(10),
+            child: Text(
+              'El equipo de desarrollo de la aplicación le pide disculpas '
+              'y le invita al grupo de Telegram para que reporte el '
+              'problema y así poder solucionarlo ayudando a los restantes '
+              'usuarios. Gracias de antemano.',
+              textAlign: TextAlign.left,
+              style: TextStyle(
+                color: Constants.primaryColor,
+                fontWeight: FontWeight.w600,
+                fontSize: 16,
               ),
             ),
           ),
-          Container(
-            padding: EdgeInsets.symmetric(horizontal: 50),
-            child: GFButton(
-              text: 'Grupo de soporte en Telegram',
-              textColor: Constants.primaryColor,
-              color: Constants.primaryColor,
-              size: GFSize.LARGE,
-              shape: GFButtonShape.pills,
-              type: GFButtonType.outline2x,
-              fullWidthButton: true,
-              onPressed: () async {
-                const url = 'https://t.me/covid19cubadatachat';
-                if (await canLaunch(url)) {
-                  await launch(url);
-                } else {
-                  log('Could not launch $url');
-                }
-              },
-            ),
+        ),
+        Container(
+          padding: EdgeInsets.symmetric(horizontal: 50),
+          child: GFButton(
+            text: 'Grupo de soporte en Telegram',
+            textColor: Constants.primaryColor,
+            color: Constants.primaryColor,
+            size: GFSize.LARGE,
+            shape: GFButtonShape.pills,
+            type: GFButtonType.outline2x,
+            fullWidthButton: true,
+            onPressed: () async {
+              const url = 'https://t.me/covid19cubadatachat';
+              if (await canLaunch(url)) {
+                await launch(url);
+              } else {
+                log('Could not launch $url');
+              }
+            },
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
The five current bottomBar pages are loaded at the beginning, and you can switch between them in no time.
AppBar and Drawer were moved to home_page removing the nested Scaffold as per recommendation in [Scaffold class docs](https://api.flutter.dev/flutter/material/Scaffold-class.html).
Cuba and World pages share the update button in AppBar, i.e, if you reload in one of them, the other one is reloaded too. Notice here that "swipe to refresh" funcionality remains independent.
Cheers!!!